### PR TITLE
Update 2020_06_06_300000_create_divisions_table.stub

### DIFF
--- a/stubs/database/migrations/2020_06_06_300000_create_divisions_table.stub
+++ b/stubs/database/migrations/2020_06_06_300000_create_divisions_table.stub
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->decimal('longitude', 10, 7);
             $table->string('timezone_id', 32)->nullable()->index();
             $table->bigInteger('population')->unsigned()->nullable();
-            $table->integer('elevation')->unsigned()->nullable()->comment('In meters.');
+            $table->integer('elevation')->nullable()->comment('In meters.');
             $table->smallInteger('dem')->nullable()->comment('Digital elevation model, srtm3 or gtopo30');
             $table->string('code', 20)->nullable()->comment('Geonames code of administrative division');
             $table->string('feature_code', 10)->nullable()->comment('See: https://www.geonames.org/export/codes.html');


### PR DESCRIPTION
Elevation was unsigned, but you can have divisions with negative elevation, causing SQL errors. This fixes issue #26.