### PR TITLE
Fix for non-unique country codes

### DIFF
--- a/src/Seeders/BaseSeeder.php
+++ b/src/Seeders/BaseSeeder.php
@@ -58,7 +58,7 @@ abstract class BaseSeeder implements Seeder, LoggerAwareInterface
         $this->logger->info('Start seeding records using "{seeder}" class', ['seeder' => static::class]);
 
         foreach ($this->getRecordsForSeeding()->chunk($this->chunkSize) as $chunk) {
-            $this->query()->insert($chunk->all());
+            $this->query()->insertOrIgnore($chunk->all());
         }
 
         $this->logger->info('Finish seeding records using "{seeder}" class', ['seeder' => static::class]);


### PR DESCRIPTION
The initial seeding somehow contains a duplicate country code, which is strange because I can't find any in the Geonames dataset. I did not explore the root cause any further.

The duplication causes the initial seeding to fail because of the unique constraint. With this fix the initial seeding is able to complete without further problems.